### PR TITLE
Files excluded from Coverage Report

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.javascript.file.suffixes=.js,.jsx
 sonar.sources=src,./functions/src
 sonar.tests=src/test
 sonar.test.inclusions=src/**/*.spec.js,src/**/*.spec.jsx,src/**/*.test.js,src/**/*.test.jsx
-sonar.exclusions=src/test/acceptance/**
+sonar.exclusions=src/test/acceptance/**, src/nightwatch.conf.js
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.clover.reportPath=coverage/clover.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,5 +5,6 @@ sonar.javascript.file.suffixes=.js,.jsx
 sonar.sources=src,./functions/src
 sonar.tests=src/test
 sonar.test.inclusions=src/**/*.spec.js,src/**/*.spec.jsx,src/**/*.test.js,src/**/*.test.jsx
+sonar.exclusions=src/test/acceptance/**
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.clover.reportPath=coverage/clover.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.javascript.file.suffixes=.js,.jsx
 sonar.sources=src,./functions/src
 sonar.tests=src/test
 sonar.test.inclusions=src/**/*.spec.js,src/**/*.spec.jsx,src/**/*.test.js,src/**/*.test.jsx
-sonar.exclusions=src/test/acceptance/**, src/nightwatch.conf.js
+sonar.exclusions=src/test/acceptance/**,src/nightwatch.conf.js
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.clover.reportPath=coverage/clover.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.javascript.file.suffixes=.js,.jsx
 sonar.sources=src,./functions/src
 sonar.tests=src/test
 sonar.test.inclusions=src/**/*.spec.js,src/**/*.spec.jsx,src/**/*.test.js,src/**/*.test.jsx
-sonar.test.exclusions=src/test/acceptance/**,src/test/nightwatch.conf.js
+sonar.exclusions=src/test/acceptance/**,src/test/nightwatch.conf.js
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.clover.reportPath=coverage/clover.xml

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -5,6 +5,6 @@ sonar.javascript.file.suffixes=.js,.jsx
 sonar.sources=src,./functions/src
 sonar.tests=src/test
 sonar.test.inclusions=src/**/*.spec.js,src/**/*.spec.jsx,src/**/*.test.js,src/**/*.test.jsx
-sonar.exclusions=src/test/acceptance/**,src/nightwatch.conf.js
+sonar.test.exclusions=src/test/acceptance/**,src/test/nightwatch.conf.js
 sonar.javascript.lcov.reportPaths=coverage/lcov.info
 sonar.clover.reportPath=coverage/clover.xml

--- a/src/test/acceptance/login_logout_test.js
+++ b/src/test/acceptance/login_logout_test.js
@@ -1,4 +1,4 @@
-
+/* istanbul ignore next */
 module.exports = {
     // TODO: set application address using a global placeholder
     'Step Login with valid credentials' : function (browser) {

--- a/src/test/nightwatch.conf.js
+++ b/src/test/nightwatch.conf.js
@@ -1,8 +1,12 @@
 // Get Selenium and the drivers
+/* istanbul ignore next */
 var seleniumServer = require('selenium-server');
+/* istanbul ignore next */
 var chromedriver = require('chromedriver');
+/* istanbul ignore next */
 var geckodriver = require('geckodriver');
 
+/* istanbul ignore next */
 var config = {
     src_folders: [
         // Folders with tests
@@ -75,5 +79,5 @@ var config = {
         },
     },
 };
-
+/* istanbul ignore next */
 module.exports = config;


### PR DESCRIPTION
- acceptance test files excluded from Sonar
- acceptance test files excluded from local coverage report.

FYI: Enzyme/Jest is using 'istanbul' to create coverage report locally. 
If you wish to exclude a statement just add the comment '/* istanbul ignore next */' in front.
